### PR TITLE
WatchableObject Support (Mainly EntityMetadataEvent)

### DIFF
--- a/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/RetrayedPlugin.java
+++ b/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/RetrayedPlugin.java
@@ -2,6 +2,7 @@ package dev.etrayed.retrayed.plugin;
 
 import com.comphenix.protocol.utility.MinecraftProtocolVersion;
 import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import dev.etrayed.retrayed.api.PluginPurpose;
 import dev.etrayed.retrayed.api.Replay;
 import dev.etrayed.retrayed.plugin.event.EventIteratorFactory;
@@ -48,7 +49,8 @@ public class RetrayedPlugin extends JavaPlugin implements IRetrayedPlugin {
         getConfig().options().copyDefaults(true);
         saveDefaultConfig();
 
-        this.executorService = Executors.newScheduledThreadPool(0);
+        this.executorService = Executors.newScheduledThreadPool(0, new ThreadFactoryBuilder()
+                .setNameFormat("Retrayed-Worker-%d").setDaemon(true).build());
 
         try {
             this.replayStorage = StorageStrategy.fromString(getConfig().getString("storageStrategy"))

--- a/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/event/AbstractEvent.java
+++ b/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/event/AbstractEvent.java
@@ -1,16 +1,8 @@
 package dev.etrayed.retrayed.plugin.event;
 
-import com.comphenix.protocol.wrappers.*;
-import com.comphenix.protocol.wrappers.nbt.NbtBase;
-import com.comphenix.protocol.wrappers.nbt.NbtCompound;
-import com.comphenix.protocol.wrappers.nbt.io.NbtBinarySerializer;
-import com.google.common.base.Optional;
 import dev.etrayed.retrayed.api.event.Event;
 import dev.etrayed.retrayed.plugin.stage.ReplayStage;
-import org.bukkit.Material;
-import org.bukkit.inventory.ItemStack;
 
-import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
@@ -25,83 +17,5 @@ public abstract class AbstractEvent implements Event {
 
     public abstract void storeIn(ObjectOutputStream outputStream) throws Exception;
 
-    protected void serializeWatchableObjectValue(WrappedWatchableObject watchableObject, ObjectOutputStream outputStream) throws IOException {
-        serializeWatchableObjectValue0(watchableObject.getValue(), outputStream);
-    }
-
-    @SuppressWarnings("unchecked")
-    private void serializeWatchableObjectValue0(Object value, ObjectOutputStream outputStream) throws IOException {
-        if(value instanceof Vector3F) {
-            outputStream.writeByte(1);
-            outputStream.writeFloat(((Vector3F) value).getX());
-            outputStream.writeFloat(((Vector3F) value).getY());
-            outputStream.writeFloat(((Vector3F) value).getZ());
-        } else if(value instanceof Optional) {
-            serializeWatchableObjectValue0(((Optional<?>) value).orNull(), outputStream);
-        } else if(value instanceof WrappedChatComponent) {
-            outputStream.writeByte(2);
-            outputStream.writeUTF(((WrappedChatComponent) value).getJson());
-        } else if(value instanceof ItemStack) {
-            outputStream.writeByte(3);
-            outputStream.writeObject(value);
-        } else if(value instanceof WrappedBlockData) {
-            outputStream.writeByte(4);
-            outputStream.writeObject(((WrappedBlockData) value).getType());
-            outputStream.writeInt(((WrappedBlockData) value).getData());
-        } else if(value instanceof BlockPosition) {
-            outputStream.writeByte(5);
-            outputStream.writeInt(((BlockPosition) value).getX());
-            outputStream.writeInt(((BlockPosition) value).getY());
-            outputStream.writeInt(((BlockPosition) value).getZ());
-        } else if(value instanceof EnumWrappers.Direction) {
-            outputStream.writeByte(6);
-            outputStream.writeObject(value);
-        } else if(value instanceof NbtCompound) {
-            outputStream.writeByte(7);
-
-            NbtBinarySerializer.DEFAULT.serialize((NbtBase) value, outputStream);
-        } else if(value instanceof WrappedChunkCoordinate) {
-            outputStream.writeByte(8);
-
-            outputStream.writeInt(((WrappedChunkCoordinate) value).getX());
-            outputStream.writeInt(((WrappedChunkCoordinate) value).getY());
-            outputStream.writeInt(((WrappedChunkCoordinate) value).getZ());
-        } else if(value instanceof ChunkPosition) {
-            outputStream.writeByte(9);
-
-            outputStream.writeInt(((ChunkPosition) value).getX());
-            outputStream.writeInt(((ChunkPosition) value).getY());
-            outputStream.writeInt(((ChunkPosition) value).getZ());
-        } else {
-            outputStream.writeByte(0);
-        }
-    }
-
     public abstract void takeFrom(ObjectInputStream inputStream) throws Exception;
-
-    protected Object deserializeWatchableObjectValue(ObjectInputStream inputStream) throws IOException, ClassNotFoundException {
-        int type = inputStream.read();
-
-        if(type == 1) {
-            return new Vector3F(inputStream.readFloat(), inputStream.readFloat(), inputStream.readFloat());
-        } else if(type == 2) {
-            return WrappedChatComponent.fromJson(inputStream.readUTF());
-        } else if(type == 3) {
-            return inputStream.readObject();
-        } else if(type == 4) {
-            return WrappedBlockData.createData((Material) inputStream.readObject(), inputStream.readInt());
-        } else if(type == 5) {
-            return new BlockPosition(inputStream.readInt(), inputStream.readInt(), inputStream.readInt());
-        } else if(type == 6) {
-            return inputStream.readObject();
-        } else if(type == 7) {
-            return NbtBinarySerializer.DEFAULT.deserializeCompound(inputStream);
-        } else if(type == 8) {
-            return new WrappedChunkCoordinate(inputStream.readInt(), inputStream.readInt(), inputStream.readInt());
-        } else if(type == 9) {
-            return new ChunkPosition(inputStream.readInt(), inputStream.readInt(), inputStream.readInt());
-        } else {
-            return null;
-        }
-    }
 }

--- a/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/event/AbstractEvent.java
+++ b/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/event/AbstractEvent.java
@@ -9,10 +9,10 @@ import dev.etrayed.retrayed.api.event.Event;
 import dev.etrayed.retrayed.plugin.stage.ReplayStage;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.util.io.BukkitObjectInputStream;
-import org.bukkit.util.io.BukkitObjectOutputStream;
 
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 
 /**
  * @author Etrayed
@@ -23,14 +23,14 @@ public abstract class AbstractEvent implements Event {
 
     public abstract void undo(ReplayStage stage);
 
-    public abstract void storeIn(BukkitObjectOutputStream outputStream) throws Exception;
+    public abstract void storeIn(ObjectOutputStream outputStream) throws Exception;
 
-    protected void serializeWatchableObjectValue(WrappedWatchableObject watchableObject, BukkitObjectOutputStream outputStream) throws IOException {
+    protected void serializeWatchableObjectValue(WrappedWatchableObject watchableObject, ObjectOutputStream outputStream) throws IOException {
         serializeWatchableObjectValue0(watchableObject.getValue(), outputStream);
     }
 
     @SuppressWarnings("unchecked")
-    private void serializeWatchableObjectValue0(Object value, BukkitObjectOutputStream outputStream) throws IOException {
+    private void serializeWatchableObjectValue0(Object value, ObjectOutputStream outputStream) throws IOException {
         if(value instanceof Vector3F) {
             outputStream.writeByte(1);
             outputStream.writeFloat(((Vector3F) value).getX());
@@ -77,9 +77,9 @@ public abstract class AbstractEvent implements Event {
         }
     }
 
-    public abstract void takeFrom(BukkitObjectInputStream inputStream) throws Exception;
+    public abstract void takeFrom(ObjectInputStream inputStream) throws Exception;
 
-    protected Object deserializeWatchableObjectValue(BukkitObjectInputStream inputStream) throws IOException, ClassNotFoundException {
+    protected Object deserializeWatchableObjectValue(ObjectInputStream inputStream) throws IOException, ClassNotFoundException {
         int type = inputStream.read();
 
         if(type == 1) {

--- a/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/event/EventRegistry.java
+++ b/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/event/EventRegistry.java
@@ -3,6 +3,7 @@ package dev.etrayed.retrayed.plugin.event;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import dev.etrayed.retrayed.plugin.event.entity.EntityEquipmentEvent;
+import dev.etrayed.retrayed.plugin.event.entity.EntityMetadataEvent;
 import dev.etrayed.retrayed.plugin.event.entity.RemoveEntityEvent;
 import dev.etrayed.retrayed.plugin.event.entity.SpawnPlayerEvent;
 
@@ -24,6 +25,7 @@ public class EventRegistry {
         registerEvent(1, SpawnPlayerEvent.class);
         registerEvent(2, RemoveEntityEvent.class);
         registerEvent(3, EntityEquipmentEvent.class);
+        registerEvent(4, EntityMetadataEvent.class);
     }
 
     void registerEvent(int id, Class<? extends AbstractEvent> eventClass) {

--- a/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/event/entity/EntityEquipmentEvent.java
+++ b/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/event/entity/EntityEquipmentEvent.java
@@ -7,8 +7,9 @@ import com.comphenix.protocol.wrappers.EnumWrappers;
 import dev.etrayed.retrayed.plugin.event.AbstractEvent;
 import dev.etrayed.retrayed.plugin.stage.ReplayStage;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.util.io.BukkitObjectInputStream;
-import org.bukkit.util.io.BukkitObjectOutputStream;
+
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 
 /**
  * @author Etrayed
@@ -75,14 +76,14 @@ public class EntityEquipmentEvent extends AbstractEvent {
     }
 
     @Override
-    public void storeIn(BukkitObjectOutputStream outputStream) throws Exception {
+    public void storeIn(ObjectOutputStream outputStream) throws Exception {
         outputStream.writeInt(entityId);
         outputStream.writeObject(equipmentSlot);
         outputStream.writeObject(itemStack);
     }
 
     @Override
-    public void takeFrom(BukkitObjectInputStream inputStream) throws Exception {
+    public void takeFrom(ObjectInputStream inputStream) throws Exception {
         this.entityId = inputStream.readInt();
         this.equipmentSlot = (VersionedEquipmentSlot) inputStream.readObject();
         this.itemStack = (ItemStack) inputStream.readObject();

--- a/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/event/entity/EntityMetadataEvent.java
+++ b/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/event/entity/EntityMetadataEvent.java
@@ -1,0 +1,92 @@
+package dev.etrayed.retrayed.plugin.event.entity;
+
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.events.PacketContainer;
+import dev.etrayed.retrayed.plugin.event.AbstractEvent;
+import dev.etrayed.retrayed.plugin.stage.ReplayStage;
+import dev.etrayed.retrayed.plugin.stage.entity.WatchableObject;
+
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * @author Etrayed
+ */
+public class EntityMetadataEvent extends AbstractEvent {
+
+    private int entityId;
+
+    private List<WatchableObject> watchableObjects;
+
+    private List<WatchableObject> cachedValues;
+
+    public EntityMetadataEvent() {
+    }
+
+    public EntityMetadataEvent(int entityId, List<WatchableObject> watchableObjects) {
+        this.entityId = entityId;
+        this.watchableObjects = watchableObjects;
+    }
+
+    @Override
+    public void recreate(ReplayStage stage) {
+        stage.findById(entityId).ifPresent(entity -> {
+            this.cachedValues = new ArrayList<>();
+
+            watchableObjects.forEach(watchableObject -> cachedValues.add(entity.watchableObject(watchableObject.index())));
+        });
+
+        sendMetadata(stage, watchableObjects);
+    }
+
+    @Override
+    public void undo(ReplayStage stage) {
+        if(cachedValues != null) {
+            stage.findById(entityId).ifPresent(entity -> {
+                for (WatchableObject cachedValue : cachedValues) {
+                    entity.setWatchableValue(cachedValue.index(), cachedValue.value());
+                }
+
+                sendMetadata(stage, cachedValues);
+            });
+        }
+    }
+
+    private void sendMetadata(ReplayStage stage, Collection<WatchableObject> watchableObjects) {
+        PacketContainer container = ProtocolLibrary.getProtocolManager().createPacket(PacketType.Play.Server.ENTITY_METADATA);
+
+        container.getIntegers().write(0, entityId);
+        container.getWatchableCollectionModifier().write(0, watchableObjects.stream().map(WatchableObject::wrap)
+                .collect(Collectors.toList()));
+
+        stage.sendPacket(container);
+    }
+
+    @Override
+    public void storeIn(ObjectOutputStream outputStream) throws Exception {
+        outputStream.writeInt(entityId);
+        outputStream.writeInt(watchableObjects.size());
+
+        for (WatchableObject watchableObject : watchableObjects) {
+            watchableObject.serializeTo(outputStream);
+        }
+    }
+
+    @Override
+    public void takeFrom(ObjectInputStream inputStream) throws Exception {
+        this.entityId = inputStream.readInt();
+
+        int watchableObjectCount = inputStream.readInt();
+
+        this.watchableObjects = new ArrayList<>(watchableObjectCount);
+
+        for (int i = 0; i < watchableObjectCount; i++) {
+            watchableObjects.add(WatchableObject.deserializeFrom(inputStream));
+        }
+    }
+}

--- a/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/event/entity/RemoveEntityEvent.java
+++ b/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/event/entity/RemoveEntityEvent.java
@@ -5,9 +5,9 @@ import com.comphenix.protocol.ProtocolLibrary;
 import com.comphenix.protocol.events.PacketContainer;
 import dev.etrayed.retrayed.plugin.event.AbstractEvent;
 import dev.etrayed.retrayed.plugin.stage.ReplayStage;
-import org.bukkit.util.io.BukkitObjectInputStream;
-import org.bukkit.util.io.BukkitObjectOutputStream;
 
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -57,12 +57,12 @@ public class RemoveEntityEvent extends AbstractEvent {
     }
 
     @Override
-    public void storeIn(BukkitObjectOutputStream outputStream) throws Exception {
+    public void storeIn(ObjectOutputStream outputStream) throws Exception {
         outputStream.writeObject(entityIds);
     }
 
     @Override
-    public void takeFrom(BukkitObjectInputStream inputStream) throws Exception {
+    public void takeFrom(ObjectInputStream inputStream) throws Exception {
         this.entityIds = (int[]) inputStream.readObject();
     }
 }

--- a/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/event/entity/SpawnPlayerEvent.java
+++ b/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/event/entity/SpawnPlayerEvent.java
@@ -8,9 +8,9 @@ import dev.etrayed.retrayed.plugin.event.AbstractEvent;
 import dev.etrayed.retrayed.plugin.stage.Position;
 import dev.etrayed.retrayed.plugin.stage.ReplayStage;
 import dev.etrayed.retrayed.plugin.stage.entity.ReplayPlayer;
-import org.bukkit.util.io.BukkitObjectInputStream;
-import org.bukkit.util.io.BukkitObjectOutputStream;
 
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -84,7 +84,7 @@ public class SpawnPlayerEvent extends AbstractEvent {
     }
 
     @Override
-    public void storeIn(BukkitObjectOutputStream outputStream) throws Exception {
+    public void storeIn(ObjectOutputStream outputStream) throws Exception {
         outputStream.writeInt(entityId);
         outputStream.writeLong(uniqueId.getMostSignificantBits());
         outputStream.writeLong(uniqueId.getLeastSignificantBits());
@@ -106,7 +106,7 @@ public class SpawnPlayerEvent extends AbstractEvent {
     }
 
     @Override
-    public void takeFrom(BukkitObjectInputStream inputStream) throws Exception {
+    public void takeFrom(ObjectInputStream inputStream) throws Exception {
         this.entityId = inputStream.readInt();
         this.uniqueId = new UUID(inputStream.readLong(), inputStream.readLong());
         this.spawnX = inputStream.readDouble();

--- a/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/event/entity/SpawnPlayerEvent.java
+++ b/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/event/entity/SpawnPlayerEvent.java
@@ -3,17 +3,18 @@ package dev.etrayed.retrayed.plugin.event.entity;
 import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.ProtocolLibrary;
 import com.comphenix.protocol.events.PacketContainer;
-import com.comphenix.protocol.wrappers.WrappedWatchableObject;
 import dev.etrayed.retrayed.plugin.event.AbstractEvent;
 import dev.etrayed.retrayed.plugin.stage.Position;
 import dev.etrayed.retrayed.plugin.stage.ReplayStage;
 import dev.etrayed.retrayed.plugin.stage.entity.ReplayPlayer;
+import dev.etrayed.retrayed.plugin.stage.entity.WatchableObject;
 
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * @author Etrayed
@@ -30,7 +31,7 @@ public class SpawnPlayerEvent extends AbstractEvent {
 
     private int itemInHand;
 
-    private List<WrappedWatchableObject> watchableObjects;
+    private List<WatchableObject> watchableObjects;
 
     public SpawnPlayerEvent() {
     }
@@ -40,7 +41,7 @@ public class SpawnPlayerEvent extends AbstractEvent {
     }
 
     public SpawnPlayerEvent(int entityId, UUID uniqueId, double spawnX, double spawnY, double spawnZ, byte yaw, byte pitch,
-                            int itemInHand, List<WrappedWatchableObject> watchableObjects) {
+                            int itemInHand, List<WatchableObject> watchableObjects) {
         this.entityId = entityId;
         this.uniqueId = uniqueId;
         this.spawnX = spawnX;
@@ -66,11 +67,13 @@ public class SpawnPlayerEvent extends AbstractEvent {
         }
 
         if(watchableObjects != null) {
-            spawnPlayerPacket.getWatchableCollectionModifier().write(0, watchableObjects);
+            spawnPlayerPacket.getWatchableCollectionModifier().write(0, watchableObjects.stream()
+                    .map(WatchableObject::wrap).collect(Collectors.toList()));
         }
 
         stage.sendPacket(spawnPlayerPacket);
-        stage.spawnEntity(new ReplayPlayer(stage.nextEntityId(), new Position(spawnX, spawnY, spawnZ, yaw, pitch), uniqueId, this));
+        stage.spawnEntity(new ReplayPlayer(stage.nextEntityId(), new Position(spawnX, spawnY, spawnZ, yaw, pitch), uniqueId,
+                this, watchableObjects));
     }
 
     @Override
@@ -96,12 +99,8 @@ public class SpawnPlayerEvent extends AbstractEvent {
         outputStream.writeInt(itemInHand);
         outputStream.writeInt(watchableObjects.size());
 
-        for (WrappedWatchableObject watchableObject : watchableObjects) {
-            outputStream.writeInt(watchableObject.getIndex());
-
-            serializeWatchableObjectValue(watchableObject, outputStream);
-
-            outputStream.writeBoolean(watchableObject.getDirtyState());
+        for (WatchableObject watchableObject : watchableObjects) {
+            watchableObject.serializeTo(outputStream);
         }
     }
 
@@ -121,11 +120,7 @@ public class SpawnPlayerEvent extends AbstractEvent {
         this.watchableObjects = new ArrayList<>(watchableObjectsSize);
 
         for (int i = 0; i < watchableObjectsSize; i++) {
-            WrappedWatchableObject object = new WrappedWatchableObject(inputStream.readInt(), deserializeWatchableObjectValue(inputStream));
-
-            object.setDirtyState(inputStream.readBoolean());
-
-            watchableObjects.add(object);
+            watchableObjects.add(WatchableObject.deserializeFrom(inputStream));
         }
     }
 }

--- a/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/stage/entity/AbstractReplayEntity.java
+++ b/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/stage/entity/AbstractReplayEntity.java
@@ -66,7 +66,16 @@ public abstract class AbstractReplayEntity implements ReplayEntity {
 
     @Override
     public final void setWatchableValue(int index, Object value) {
-        watchableObjects.computeIfAbsent(index, WatchableObject::new).setValue(value);
+        if(value == null) {
+            watchableObjects.remove(index);
+        } else {
+            watchableObjects.computeIfAbsent(index, WatchableObject::new).setValue(value);
+        }
+    }
+
+    @Override
+    public WatchableObject watchableObject(int index) {
+        return watchableObjects.get(index);
     }
 
     @Override

--- a/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/stage/entity/AbstractReplayEntity.java
+++ b/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/stage/entity/AbstractReplayEntity.java
@@ -5,6 +5,11 @@ import dev.etrayed.retrayed.plugin.event.entity.EntityEquipmentEvent;
 import dev.etrayed.retrayed.plugin.stage.Position;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 /**
  * @author Etrayed
  */
@@ -18,14 +23,16 @@ public abstract class AbstractReplayEntity implements ReplayEntity {
 
     private ItemStack[] equipment;
 
-    public AbstractReplayEntity(int id, Position position) {
-        this(id, position, null);
-    }
+    private Map<Integer, WatchableObject> watchableObjects;
 
-    public AbstractReplayEntity(int id, Position position, AbstractEvent spawnEvent) {
+    public AbstractReplayEntity(int id, Position position, AbstractEvent spawnEvent,
+                                Collection<WatchableObject> watchableObjects) {
         this.id = id;
         this.position = position;
         this.spawnEvent = spawnEvent;
+        this.watchableObjects = new ConcurrentHashMap<>();
+
+        watchableObjects.forEach(watchableObject -> this.watchableObjects.put(watchableObject.index(), watchableObject));
     }
 
     @Override
@@ -44,7 +51,7 @@ public abstract class AbstractReplayEntity implements ReplayEntity {
     }
 
     @Override
-    public void setEquipment(EntityEquipmentEvent.VersionedEquipmentSlot equipmentSlot, ItemStack itemStack) {
+    public final void setEquipment(EntityEquipmentEvent.VersionedEquipmentSlot equipmentSlot, ItemStack itemStack) {
         if(equipment == null) {
             equipment = new ItemStack[EntityEquipmentEvent.VersionedEquipmentSlot.values().length];
         }
@@ -53,7 +60,24 @@ public abstract class AbstractReplayEntity implements ReplayEntity {
     }
 
     @Override
-    public ItemStack equipment(EntityEquipmentEvent.VersionedEquipmentSlot equipmentSlot) {
+    public final ItemStack equipment(EntityEquipmentEvent.VersionedEquipmentSlot equipmentSlot) {
         return equipment == null ? null : equipment[equipmentSlot.ordinal()];
+    }
+
+    @Override
+    public final void setWatchableValue(int index, Object value) {
+        watchableObjects.computeIfAbsent(index, WatchableObject::new).setValue(value);
+    }
+
+    @Override
+    public final Object watchableValue(int index) {
+        WatchableObject watchableObject = watchableObjects.get(index);
+
+        return watchableObject == null ? null : watchableObject.value();
+    }
+
+    @Override
+    public final Collection<WatchableObject> watchableObjects() {
+        return Collections.unmodifiableCollection(watchableObjects.values());
     }
 }

--- a/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/stage/entity/ReplayEntity.java
+++ b/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/stage/entity/ReplayEntity.java
@@ -24,6 +24,8 @@ public interface ReplayEntity {
 
     void setWatchableValue(int index, Object value);
 
+    WatchableObject watchableObject(int index);
+
     Object watchableValue(int index);
 
     Collection<WatchableObject> watchableObjects();

--- a/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/stage/entity/ReplayEntity.java
+++ b/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/stage/entity/ReplayEntity.java
@@ -5,6 +5,8 @@ import dev.etrayed.retrayed.plugin.event.entity.EntityEquipmentEvent;
 import dev.etrayed.retrayed.plugin.stage.Position;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.Collection;
+
 /**
  * @author Etrayed
  */
@@ -19,4 +21,10 @@ public interface ReplayEntity {
     void setEquipment(EntityEquipmentEvent.VersionedEquipmentSlot equipmentSlot, ItemStack itemStack);
 
     ItemStack equipment(EntityEquipmentEvent.VersionedEquipmentSlot equipmentSlot);
+
+    void setWatchableValue(int index, Object value);
+
+    Object watchableValue(int index);
+
+    Collection<WatchableObject> watchableObjects();
 }

--- a/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/stage/entity/ReplayPlayer.java
+++ b/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/stage/entity/ReplayPlayer.java
@@ -3,6 +3,7 @@ package dev.etrayed.retrayed.plugin.stage.entity;
 import dev.etrayed.retrayed.plugin.event.entity.SpawnPlayerEvent;
 import dev.etrayed.retrayed.plugin.stage.Position;
 
+import java.util.Collection;
 import java.util.UUID;
 
 /**
@@ -12,8 +13,9 @@ public class ReplayPlayer extends AbstractReplayEntity {
 
     private final UUID uniqueId;
 
-    public ReplayPlayer(int id, Position position, UUID uniqueId, SpawnPlayerEvent spawnEvent) {
-        super(id, position, spawnEvent);
+    public ReplayPlayer(int id, Position position, UUID uniqueId, SpawnPlayerEvent spawnEvent,
+                        Collection<WatchableObject> watchableObjects) {
+        super(id, position, spawnEvent, watchableObjects);
 
         this.uniqueId = uniqueId;
     }

--- a/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/stage/entity/WatchableObject.java
+++ b/retrayed-plugin/src/main/java/dev/etrayed/retrayed/plugin/stage/entity/WatchableObject.java
@@ -1,0 +1,132 @@
+package dev.etrayed.retrayed.plugin.stage.entity;
+
+import com.comphenix.protocol.wrappers.*;
+import com.comphenix.protocol.wrappers.nbt.NbtBase;
+import com.comphenix.protocol.wrappers.nbt.NbtCompound;
+import com.comphenix.protocol.wrappers.nbt.io.NbtBinarySerializer;
+import com.google.common.base.Optional;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+/**
+ * @author Etrayed
+ */
+public final class WatchableObject {
+
+    private final int index;
+
+    private Object value;
+
+    public WatchableObject(int index) {
+        this(index, null);
+    }
+
+    public WatchableObject(int index, Object value) {
+        this.index = index;
+        this.value = value;
+    }
+
+    public int index() {
+        return index;
+    }
+
+    public Object value() {
+        return value;
+    }
+
+    public void setValue(Object value) {
+        this.value = value;
+    }
+
+    public void serializeTo(ObjectOutputStream outputStream) throws IOException {
+        outputStream.writeInt(index);
+
+        serializeValueTo(outputStream, value);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void serializeValueTo(ObjectOutputStream outputStream, Object value) throws IOException {
+        if(value instanceof Vector3F) {
+            outputStream.writeByte(1);
+            outputStream.writeFloat(((Vector3F) value).getX());
+            outputStream.writeFloat(((Vector3F) value).getY());
+            outputStream.writeFloat(((Vector3F) value).getZ());
+        } else if(value instanceof Optional) {
+            serializeValueTo(outputStream, ((Optional<?>) value).orNull());
+        } else if(value instanceof WrappedChatComponent) {
+            outputStream.writeByte(2);
+            outputStream.writeUTF(((WrappedChatComponent) value).getJson());
+        } else if(value instanceof ItemStack) {
+            outputStream.writeByte(3);
+            outputStream.writeObject(value);
+        } else if(value instanceof WrappedBlockData) {
+            outputStream.writeByte(4);
+            outputStream.writeObject(((WrappedBlockData) value).getType());
+            outputStream.writeInt(((WrappedBlockData) value).getData());
+        } else if(value instanceof BlockPosition) {
+            outputStream.writeByte(5);
+            outputStream.writeInt(((BlockPosition) value).getX());
+            outputStream.writeInt(((BlockPosition) value).getY());
+            outputStream.writeInt(((BlockPosition) value).getZ());
+        } else if(value instanceof EnumWrappers.Direction) {
+            outputStream.writeByte(6);
+            outputStream.writeObject(value);
+        } else if(value instanceof NbtCompound) {
+            outputStream.writeByte(7);
+
+            NbtBinarySerializer.DEFAULT.serialize((NbtBase) value, outputStream);
+        } else if(value instanceof WrappedChunkCoordinate) {
+            outputStream.writeByte(8);
+
+            outputStream.writeInt(((WrappedChunkCoordinate) value).getX());
+            outputStream.writeInt(((WrappedChunkCoordinate) value).getY());
+            outputStream.writeInt(((WrappedChunkCoordinate) value).getZ());
+        } else if(value instanceof ChunkPosition) {
+            outputStream.writeByte(9);
+
+            outputStream.writeInt(((ChunkPosition) value).getX());
+            outputStream.writeInt(((ChunkPosition) value).getY());
+            outputStream.writeInt(((ChunkPosition) value).getZ());
+        } else {
+            outputStream.writeByte(0);
+        }
+    }
+
+    public WrappedWatchableObject wrap() {
+        return new WrappedWatchableObject(index, value instanceof AbstractWrapper ? ((AbstractWrapper) value).getHandle() : value);
+    }
+
+    public static WatchableObject deserializeFrom(ObjectInputStream inputStream) throws IOException, ClassNotFoundException {
+        return new WatchableObject(inputStream.readInt(), deserializeValueFrom(inputStream));
+    }
+
+    private static Object deserializeValueFrom(ObjectInputStream inputStream) throws IOException, ClassNotFoundException {
+        int type = inputStream.read();
+
+        if(type == 1) {
+            return new Vector3F(inputStream.readFloat(), inputStream.readFloat(), inputStream.readFloat());
+        } else if(type == 2) {
+            return WrappedChatComponent.fromJson(inputStream.readUTF());
+        } else if(type == 3) {
+            return inputStream.readObject();
+        } else if(type == 4) {
+            return WrappedBlockData.createData((Material) inputStream.readObject(), inputStream.readInt());
+        } else if(type == 5) {
+            return new BlockPosition(inputStream.readInt(), inputStream.readInt(), inputStream.readInt());
+        } else if(type == 6) {
+            return inputStream.readObject();
+        } else if(type == 7) {
+            return NbtBinarySerializer.DEFAULT.deserializeCompound(inputStream);
+        } else if(type == 8) {
+            return new WrappedChunkCoordinate(inputStream.readInt(), inputStream.readInt(), inputStream.readInt());
+        } else if(type == 9) {
+            return new ChunkPosition(inputStream.readInt(), inputStream.readInt(), inputStream.readInt());
+        } else {
+            return null;
+        }
+    }
+}

--- a/retrayed-plugin/src/test/java/dev/etrayed/retrayed/plugin/event/DummyEvent.java
+++ b/retrayed-plugin/src/test/java/dev/etrayed/retrayed/plugin/event/DummyEvent.java
@@ -1,8 +1,9 @@
 package dev.etrayed.retrayed.plugin.event;
 
 import dev.etrayed.retrayed.plugin.stage.ReplayStage;
-import org.bukkit.util.io.BukkitObjectInputStream;
-import org.bukkit.util.io.BukkitObjectOutputStream;
+
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 
 /**
  * @author Etrayed
@@ -22,12 +23,12 @@ public class DummyEvent extends AbstractEvent {
     }
 
     @Override
-    public void storeIn(BukkitObjectOutputStream outputStream) throws Exception {
+    public void storeIn(ObjectOutputStream outputStream) throws Exception {
         outputStream.writeInt(anInt);
     }
 
     @Override
-    public void takeFrom(BukkitObjectInputStream inputStream) throws Exception {
+    public void takeFrom(ObjectInputStream inputStream) throws Exception {
         this.anInt = inputStream.readInt();
     }
 


### PR DESCRIPTION
Replaced ProtocolLibs WrappedWatchableObject with our own and moved (de)serialization stuff there. Also reduced BukkitObjectIn/OutputStream usages.